### PR TITLE
Fix issue windows compilation issue.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,9 +12,8 @@
       'conditions': [
         ['OS == "linux"', { 'sources': [ '<(gamepad_dir)/Gamepad_linux.c' ]}],
         ['OS == "mac"', { 'sources': [ '<(gamepad_dir)/Gamepad_macosx.c' ]}],
-        ['OS == "windows"', { 'sources': [
+        ['OS == "win"', { 'sources': [
           '<(gamepad_dir)/Gamepad_windows_dinput.c'
-          '<(gamepad_dir)/Gamepad_windows_mm.c'
         ]}]
       ],
       'include_dirs': [


### PR DESCRIPTION
This fixes issue #1, which causes compilation to fail on windows.

Also when compiling on windows make sure to call `npm install` with `--msvs_version=2013` if multiple versions of msvs is installed.
