### PR TITLE
Refactor to use nan

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -18,6 +18,7 @@
       ],
       'include_dirs': [
         './gamepad/source',
+        "<!(node -e \"require('nan')\")"
       ],
     },
     {

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,20 @@
       ],
       'conditions': [
         ['OS == "linux"', { 'sources': [ '<(gamepad_dir)/Gamepad_linux.c' ]}],
-        ['OS == "mac"', { 'sources': [ '<(gamepad_dir)/Gamepad_macosx.c' ]}],
+        ['OS == "mac"', {
+          'sources': [ '<(gamepad_dir)/Gamepad_macosx.c' ],
+          'LDFLAGS': [
+            '-framework IOKit',
+            '-framework CoreFoundation'
+          ],
+          'xcode_settings': {
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'OTHER_LDFLAGS': [
+              '-framework IOKit',
+              '-framework CoreFoundation'
+            ],
+          }
+        }],
         ['OS == "win"', { 'sources': [
           '<(gamepad_dir)/Gamepad_windows_dinput.c'
         ]}]

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "install": "node-pre-gyp install --fallback-to-build"
   },
  "dependencies": {
+    "nan": "1.8.4",
     "node-pre-gyp": "0.6.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "install": "node-pre-gyp install --fallback-to-build"
   },
  "dependencies": {
-    "node-pre-gyp": "0.5.31"
+    "node-pre-gyp": "0.6.7"
   },
   "devDependencies": {
-    "aws-sdk": "~2.0.21"
+    "aws-sdk": "~2.1.36"
   },
   "bundledDependencies":["node-pre-gyp"],
   "binary": {


### PR DESCRIPTION
This PR refactors `gamepad` to use https://github.com/nodejs/nan for better support across different versions of Node/iojs. 

Additionally, outdated dependencies have been updated, and an issue with OS X on newer versions of v8 has been addressed with an update to `binding.gyp`.

I've only been able to test that this works on OS X, but have confirmed support for the following:

- io/2.2.1
- io/2.3.1
- node/0.10.38
- node/0.12.5

If any Linux or Windows users could test building from source and running `sample.js` with a controller, it would be much appreciated.