### PR TITLE
Publish pre-built binaries for Windows to S3 bucket

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ build_script:
 on_success:
   - cmd: IF %PUBLISH_BINARY%==true (npm install aws-sdk)
   - cmd: IF %PUBLISH_BINARY%==true (node-pre-gyp package 2>&1)
-  - cmd: IF %PUBLISH_BINARY%==true (node-pre-gyp-github publish --release 2>&1)
+  - cmd: IF %PUBLISH_BINARY%==true (node-pre-gyp publish 2>&1)
   - cmd: IF %PUBLISH_BINARY%==true (node-pre-gyp clean)
   - cmd: IF %PUBLISH_BINARY%==true (npm install --fallback-to-build=false)
 


### PR DESCRIPTION
We need to publish pre-built binaries for Windows to S3 bucket, not to Github. This corrects the appveyor.yml file.