### PR TITLE
Update nan and node-pre-gyp to latest versions for Node 6.x+

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "install": "node-pre-gyp install --fallback-to-build"
   },
  "dependencies": {
-    "nan": "2.0.9",
-    "node-pre-gyp": "0.6.27"
+    "nan": "2.4.0",
+    "node-pre-gyp": "0.6.30"
   },
   "devDependencies": {
     "aws-sdk": "~2.1.36"


### PR DESCRIPTION
Update nan and node-pre-gyp to latest versions for Node 6.x+ compatibility. 'nuff said! :)
