### PR TITLE
Added additional information to gampad devices

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -30,6 +30,8 @@ Local<Object> nGamepad_toObject(Gamepad_device* device) {
   obj->Set(Nan::New("description").ToLocalChecked(), Nan::New<String>(device->description).ToLocalChecked());
   obj->Set(Nan::New("vendorID").ToLocalChecked(), Nan::New<Number>(device->vendorID));
   obj->Set(Nan::New("productID").ToLocalChecked(), Nan::New<Number>(device->productID));
+  obj->Set(Nan::New("busType").ToLocalChecked(), Nan::New<Number>(device->busType));
+  obj->Set(Nan::New("version").ToLocalChecked(), Nan::New<Number>(device->version));
   Handle<Array> axes = Nan::New<Array>(device->numAxes);
   for (unsigned int i = 0; i < device->numAxes; i++) {
     axes->Set(i, Nan::New<Number>(device->axisStates[i]));

--- a/gamepad/source/gamepad/Gamepad.h
+++ b/gamepad/source/gamepad/Gamepad.h
@@ -47,6 +47,10 @@ struct Gamepad_device {
 	int vendorID;
 	int productID;
 	
+	// Bust type and version as returned by driver
+        int busType; 
+        int version;
+	
 	// Number of axis elements belonging to the device
 	unsigned int numAxes;
 	

--- a/gamepad/source/gamepad/Gamepad_linux.c
+++ b/gamepad/source/gamepad/Gamepad_linux.c
@@ -349,6 +349,8 @@ void Gamepad_detectDevices() {
 				if (!ioctl(fd, EVIOCGID, &id)) {
 					deviceRecord->vendorID = id.vendor;
 					deviceRecord->productID = id.product;
+					deviceRecord->busType = id.bustype;
+					deviceRecord->version = id.version;
 				} else {
 					deviceRecord->vendorID = deviceRecord->productID = 0;
 				}


### PR DESCRIPTION
I have a situation requiring all data in `struct input_id` to be returned to node.js. I made these changes on a local branch and figured I would share:
```
struct input_id {
	__u16 bustype;
	__u16 vendor;
	__u16 product;
	__u16 version;
};
```

Thanks for the great library. Let me know if you need anything further.