### PR TITLE
Resolve #15 segmentation fault due to buttonStates being incorrectly sized

### DIFF
--- a/gamepad/source/gamepad/Gamepad_linux.c
+++ b/gamepad/source/gamepad/Gamepad_linux.c
@@ -378,7 +378,7 @@ void Gamepad_detectDevices() {
 				}
 				
 				deviceRecord->axisStates = calloc(sizeof(float), deviceRecord->numAxes);
-				deviceRecord->buttonStates = calloc(sizeof(bool), deviceRecord->numButtons);
+				deviceRecord->buttonStates = calloc(sizeof(true), deviceRecord->numButtons);
 				
 				if (Gamepad_deviceAttachCallback != NULL) {
 					Gamepad_deviceAttachCallback(deviceRecord, Gamepad_deviceAttachContext);

--- a/gamepad/source/gamepad/Gamepad_macosx.c
+++ b/gamepad/source/gamepad/Gamepad_macosx.c
@@ -331,7 +331,7 @@ static void onDeviceMatched(void * context, IOReturn result, void * sender, IOHI
 	CFRelease(elements);
 	
 	deviceRecord->axisStates = calloc(sizeof(float), deviceRecord->numAxes);
-	deviceRecord->buttonStates = calloc(sizeof(bool), deviceRecord->numButtons);
+	deviceRecord->buttonStates = calloc(sizeof(true), deviceRecord->numButtons);
 	
 	IOHIDDeviceRegisterInputValueCallback(device, onDeviceValueChanged, deviceRecord);
 	

--- a/gamepad/source/gamepad/Gamepad_windows_dinput.c
+++ b/gamepad/source/gamepad/Gamepad_windows_dinput.c
@@ -732,7 +732,7 @@ static BOOL CALLBACK enumDevicesCallback(const DIDEVICEINSTANCE * instance, LPVO
 	deviceRecord->numButtons = 0;
 	IDirectInputDevice_EnumObjects(di8Device, countButtonsCallback, deviceRecord, DIDFT_BUTTON);
 	deviceRecord->axisStates = calloc(sizeof(float), deviceRecord->numAxes);
-	deviceRecord->buttonStates = calloc(sizeof(bool), deviceRecord->numButtons);
+	deviceRecord->buttonStates = calloc(sizeof(true), deviceRecord->numButtons);
 	deviceRecordPrivate->axisInfo = calloc(sizeof(struct diAxisInfo), deviceRecord->numAxes);
 	deviceRecordPrivate->buttonOffsets = calloc(sizeof(DWORD), deviceRecord->numButtons);
 	deviceRecord->numAxes = 0;

--- a/gamepad/source/gamepad/Gamepad_windows_mm.c
+++ b/gamepad/source/gamepad/Gamepad_windows_mm.c
@@ -183,7 +183,7 @@ void Gamepad_detectDevices() {
 			deviceRecord->numAxes = caps.wNumAxes + ((caps.wCaps & JOYCAPS_HASPOV) ? 2 : 0);
 			deviceRecord->numButtons = caps.wNumButtons;
 			deviceRecord->axisStates = calloc(sizeof(float), deviceRecord->numAxes);
-			deviceRecord->buttonStates = calloc(sizeof(bool), deviceRecord->numButtons);
+			deviceRecord->buttonStates = calloc(sizeof(true), deviceRecord->numButtons);
 			devices = realloc(devices, sizeof(struct Gamepad_device *) * (numDevices + 1));
 			devices[numDevices++] = deviceRecord;
 			


### PR DESCRIPTION
`sizeof(bool)` is 1, whereas `buttonStates` is being assigned values with `sizeof(int)` = 4.

I'm not very familiar with C, but apparently `stdbool.h` defines `true` and `false` as type `int`. (https://stackoverflow.com/questions/47010910/why-does-sizeofa-true-false-give-an-output-of-four-bytes).

This fixes the segmentation faults for me on macOS. I'm assuming the same fix is relevant for Linux and Windows, but haven't tested those platforms myself.